### PR TITLE
Typo in license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -28,7 +28,7 @@ In summary this:
 - allows you to distribute UNMODIFIED VERSIONS of MarchingSquaresJS under any
   license as long as this license notice is included
 - enables you to keep the source code of your program that uses MarchingSquaresJS
-  disclosed
+  undisclosed
 - forces you to share any modifications you have made to MarchingSquaresJS,
   e.g. bug-fixes
 


### PR DESCRIPTION
The summary is misleading as the typo makes it look like the license DOES force you to disclose the source code.